### PR TITLE
Update jquery.city-autocomplete.js

### DIFF
--- a/jquery.city-autocomplete.js
+++ b/jquery.city-autocomplete.js
@@ -2,7 +2,8 @@
     $.fn.cityAutocomplete = function(options) {
         var settings = $.extend({
             show_state: false,
-            show_country: false
+            show_country: false,
+            min_length: 0
         }, options);
         var autocompleteService = new google.maps.places.AutocompleteService();
         var predictionsDropDown = $('<div class="city-autocomplete"></div>').appendTo('body');
@@ -11,7 +12,7 @@
         input.keyup(function() {
             var searchStr = $(this).val();
 
-            if (searchStr.length > 0) {
+            if ((settings.min_length > 0 && searchStr.length >= settings.min_length) || (settings.min_length === 0 && searchStr.length>0)) {
                 var params = {
                     input: searchStr,
                     types: ['(cities)']


### PR DESCRIPTION
added min_length setting to handle minimum chars number before calling Google API to search for inserted text. It can be useful to avoid multiple calls to Google servers